### PR TITLE
Add linuxmuster-cachingserver-linbo7 as alternative dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper, docker-ce | moby-engine, docker-ce-cli | moby-cli
 
 Package: linuxmuster-linbo-gui7
 Architecture: all
-Depends: linuxmuster-linbo7 (>= 4.1.0)
+Depends: linuxmuster-linbo7 (>= 4.1.0) | linuxmuster-cachingserver-linbo7
 Description: Linuxmuster Linbo GUI
  This package contains the GUI for the Linux-based Network Boot
  (LINBO) boot/install/repair system.


### PR DESCRIPTION
To enable the future use of a Linbo caching server, we also need the Linbo GUI on the caching server. Since a renamed fork of the linuxmuster-linbo7 package with some adjustments is used there, it would make sense if we added the linuxmuster-cachingserver-linbo7 package as another possible dependency to the package.